### PR TITLE
Refactor NameStyle enum by replacing switch block

### DIFF
--- a/src/main/java/com/jparams/verifier/tostring/NameStyle.java
+++ b/src/main/java/com/jparams/verifier/tostring/NameStyle.java
@@ -3,35 +3,36 @@ package com.jparams.verifier.tostring;
 /**
  * Style of the class name
  */
-public enum NameStyle
-{
+public enum NameStyle {
     /**
      * Tests the name of the class is present as returned by {@link Class#getName()}.
      */
-    NAME,
+    NAME {
+        @Override
+        public String getName(Class<?> clazz) {
+            return clazz.getName();
+        }
+    },
 
     /**
      * Tests the name of the class is present as returned by {@link Class#getSimpleName()}.
      */
-    SIMPLE_NAME,
+    SIMPLE_NAME {
+        @Override
+        public String getName(Class<?> clazz) {
+            return clazz.getSimpleName();
+        }
+    },
 
     /**
      * Tests the name of the class is present as returned by {@link Class#getCanonicalName()}.
      */
-    CANONICAL_NAME;
-
-    public String getName(final Class<?> clazz)
-    {
-        switch (this)
-        {
-            case NAME:
-                return clazz.getName();
-            case SIMPLE_NAME:
-                return clazz.getSimpleName();
-            case CANONICAL_NAME:
-                return clazz.getCanonicalName();
-            default:
-                throw new UnsupportedOperationException("Unknown name type " + this);
+    CANONICAL_NAME {
+        @Override
+        public String getName(Class<?> clazz) {
+            return clazz.getCanonicalName();
         }
-    }
+    };
+
+    public abstract String getName(Class<?> clazz);
 }


### PR DESCRIPTION
Replacing the switch block by making `getName` abstract.
This way the `default` path is obsolete.

See Chapter 6 of Effective Java (3rd edition) by Joshua Bloch or
https://github.com/jbloch/effective-java-3e-source-code/blob/master/src/effectivejava/chapter6/item34/Operation.java