### PR TITLE
Fix issue when the project path contains whitespaces

### DIFF
--- a/src/main/java/com/jparams/verifier/tostring/PackageScanner.java
+++ b/src/main/java/com/jparams/verifier/tostring/PackageScanner.java
@@ -2,6 +2,7 @@ package com.jparams.verifier.tostring;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +45,7 @@ final class PackageScanner
 
         while (resources.hasMoreElements())
         {
-            final File directory = new File(resources.nextElement().getFile());
+            final File directory = new File(getResourcePath(resources.nextElement()));
             rootDirectories.add(directory);
         }
 
@@ -52,6 +53,16 @@ final class PackageScanner
                               .map(rootDirectory -> findClasses(rootDirectory, packageName, recursively))
                               .flatMap(List::stream)
                               .collect(Collectors.toList());
+    }
+
+    private static String getResourcePath(URL r) {
+        try
+        {
+            return r.toURI().getPath();
+        } catch (URISyntaxException e)
+        {
+            throw new PackageScanException(e);
+        }
     }
 
     private static List<Class<?>> findClasses(final File rootDirectory, final String packageName, final boolean recursively)


### PR DESCRIPTION
If we have a project on the computer in a directory that contains spaces (example: _C:\Documents and Settings\Projects\MyProject_), the library resolves the path of the directories by calling the method `URL.getFile()`.
The paths contain `%20` characters instead of spaces.
When the library checks if the directory exists (`File.exists()`), then it does not find the directory.

The solution is to replace `URL.getFile()` by `URL.toURI().getPath()`.

References : 
https://community.oracle.com/tech/developers/discussion/2058345/url-getfile-outputs-20-as-space
https://stackoverflow.com/questions/3263560/sysloader-getresource-problem-in-java